### PR TITLE
installation: fix ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.5.1',
+        'Sphinx>=1.4.4,<2.0',
         'sphinx-rtd-theme>=0.1.9',
         'sphinx-click>=1.0.4',
     ],
@@ -62,6 +62,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author='CERN Analysis Preservation',
     author_email='analysis-preservation-team@cern.ch',
+    packages=['twikiget', ],
     extras_require=extras_require,
     install_requires=install_requires,
     setup_requires=setup_requires,

--- a/twikiget/__init__.py
+++ b/twikiget/__init__.py
@@ -8,6 +8,8 @@
 
 """twikiget."""
 
+from __future__ import absolute_import, print_function
+
 from .version import __version__
 
-__all__ = ('__version__', )
+__all__ = ('__version__')


### PR DESCRIPTION
- Fix an error which happened when trying to install twikiget in
  non-editable mode (Closes #14).

- Pin Sphinx version because it caused a dependency conflict.

Signed-off-by: Jan Okraska <jan.okraska@cern.ch>